### PR TITLE
Android: Fixed bug for not displaying notifications

### DIFF
--- a/PushNotification/PushNotification/PushNotification.Plugin.Android/PushNotificationGcmListener.cs
+++ b/PushNotification/PushNotification/PushNotification.Plugin.Android/PushNotificationGcmListener.cs
@@ -141,7 +141,7 @@ namespace PushNotification.Plugin
 
                         }
                     }
-                        else
+                        else if (parameters.ContainsKey(PushNotificationKey.Title))
                         {
                             message = parameters[PushNotificationKey.Title].ToString();
                         }


### PR DESCRIPTION
Notifications weren't displayed anymore in the notification tray on Android because of an exception thrown after getting the title parameters. I added an extra check.
