### PR TITLE
Added support for long message on Android using BigTextStyle 

### DIFF
--- a/PushNotification/PushNotification/PushNotification.Plugin.Android/PushNotificationGcmListener.cs
+++ b/PushNotification/PushNotification/PushNotification.Plugin.Android/PushNotificationGcmListener.cs
@@ -260,6 +260,13 @@ namespace PushNotification.Plugin
                       .SetSmallIcon(CrossPushNotification.IconResource) // This is the icon to display
                       .SetContentText(message); // the message to display.
 
+			if (Android.OS.Build.VERSION.SdkInt >= Android.OS.BuildVersionCodes.JellyBean) {
+				// Using BigText notification style to support long message
+				var style = new NotificationCompat.BigTextStyle ();
+				style.BigText (message);
+				builder.SetStyle (style);
+			}
+
             NotificationManager notificationManager = (NotificationManager)context.GetSystemService(Context.NotificationService);
             notificationManager.Notify(tag, notifyId, builder.Build());
 


### PR DESCRIPTION
The default SetContentText does not support long extendable text for long notification messages.
On Android 4.1 there's support for BigTextStyle notifications to show long text messages.
