### PR TITLE
Fix attributes so registration is automatic.

### DIFF
--- a/PushNotification/PushNotification/PushNotification.Plugin.Android/Properties/AssemblyInfo.cs
+++ b/PushNotification/PushNotification/PushNotification.Plugin.Android/Properties/AssemblyInfo.cs
@@ -1,11 +1,7 @@
 ﻿using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using Android.App;
 
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
 [assembly: AssemblyTitle("PushNotification.Plugin.Android")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
@@ -14,17 +10,12 @@ using Android.App;
 [assembly: AssemblyCopyright("Copyright ©  2014")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
-[assembly: ComVisible(false)]
 
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+
+[assembly: Permission(Name = "@PACKAGE_NAME@.permission.C2D_MESSAGE")]
+[assembly: UsesPermission(Name = "android.permission.WAKE_LOCK")]
+[assembly: UsesPermission(Name = "com.google.android.c2dm.permission.RECEIVE")]
+[assembly: UsesPermission(Name = "android.permission.GET_ACCOUNTS")]
+[assembly: UsesPermission(Name = "android.permission.INTERNET")]

--- a/PushNotification/PushNotification/PushNotification.Plugin.Android/PushNotificationGcmListener.cs
+++ b/PushNotification/PushNotification/PushNotification.Plugin.Android/PushNotificationGcmListener.cs
@@ -21,7 +21,7 @@ namespace PushNotification.Plugin
     /// Push Notification Message Handler
     /// </summary>
     [Service(Exported=false, Name="pushnotification.plugin.PushNotificationGcmListener")]
-    [IntentFilter(new string[] { "com.google.android.c2dm.intent.RECEIVE", "com.google.android.c2dm.intent.REGISTRATION" }, Categories = new string[] { "@PACKAGE_NAME@" })]
+    [IntentFilter(new string[] { "com.google.android.c2dm.intent.RECEIVE" }, Categories = new string[] { "@PACKAGE_NAME@" })]
     public class PushNotificationGcmListener : GcmListenerService
     {
         /// <summary>

--- a/PushNotification/PushNotification/PushNotification.Plugin.Android/PushNotificationGcmListener.cs
+++ b/PushNotification/PushNotification/PushNotification.Plugin.Android/PushNotificationGcmListener.cs
@@ -20,8 +20,8 @@ namespace PushNotification.Plugin
     /// <summary>
     /// Push Notification Message Handler
     /// </summary>
-    [Service(Exported=false)]
-    [IntentFilter(new string[] { "com.google.android.c2dm.intent.RECEIVE" })]
+    [Service(Exported=false, Name="pushnotification.plugin.PushNotificationGcmListener")]
+    [IntentFilter(new string[] { "com.google.android.c2dm.intent.RECEIVE", "com.google.android.c2dm.intent.REGISTRATION" }, Categories = new string[] { "@PACKAGE_NAME@" })]
     public class PushNotificationGcmListener : GcmListenerService
     {
         /// <summary>

--- a/PushNotification/PushNotification/PushNotification.Plugin.Android/PushNotificationsReceiver.cs
+++ b/PushNotification/PushNotification/PushNotification.Plugin.Android/PushNotificationsReceiver.cs
@@ -1,21 +1,6 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Android.Support.V4.Content;
 using Android.App;
 using Android.Content;
-using Android.OS;
-using Android.Runtime;
-using Android.Views;
-using Android.Widget;
 using Android.Gms.Gcm;
-
-[assembly: Permission(Name = "@PACKAGE_NAME@.permission.C2D_MESSAGE")]
-[assembly: UsesPermission(Name = "android.permission.WAKE_LOCK")]
-[assembly: UsesPermission(Name = "com.google.android.c2dm.permission.RECEIVE")]
-[assembly: UsesPermission(Name = "android.permission.GET_ACCOUNTS")]
-[assembly: UsesPermission(Name = "android.permission.INTERNET")]
 
 namespace PushNotification.Plugin
 {


### PR DESCRIPTION
This PR fixes #46 by fixing up the attributes on `PushNotificationGcmListener`. I also moved the assembly-level attributes out of _ PushNotificationsReceiver.cs_ (where they're hard to find) and into _AssemblyInfo.cs_.
