### PR TITLE
Fix parameter name

### DIFF
--- a/PushNotification/PushNotification/content/CrossPushNotificationListener.txt.pp
+++ b/PushNotification/PushNotification/content/CrossPushNotificationListener.txt.pp
@@ -20,7 +20,7 @@ namespace $rootnamespace$.Helpers
             Debug.WriteLine("Message Arrived");
         }
 
-        public void OnRegistered(string token, DeviceType deviceType)
+        public void OnRegistered(string Token, DeviceType deviceType)
         {
             Debug.WriteLine(string.Format("Push Notification - Device Registered - Token : {0}", Token));
         }


### PR DESCRIPTION
On public void OnRegistered(string token, DeviceType deviceType) the parameter token is defined with a lower case t whereas on the method body is refereed to as Token with a capital T.
