### PR TITLE
Call OnUnregisteredSuccess in Unregister on iOS

### DIFF
--- a/PushNotification/PushNotification/PushNotification.Plugin.iOS/PushNotificationImplementation.cs
+++ b/PushNotification/PushNotification/PushNotification.Plugin.iOS/PushNotificationImplementation.cs
@@ -48,8 +48,9 @@ namespace PushNotification.Plugin
 
 			UIApplication.SharedApplication.UnregisterForRemoteNotifications();
 
+            OnUnregisteredSuccess();
 
-		}
+        }
 
       private static string DictionaryToJson(NSDictionary dictionary)
       {


### PR DESCRIPTION
On iOS OnUnregistered of PushNotificationListener is never called and token is not cleaned up.
