### PR TITLE
Access to token in OnUnregistered on iOS

### DIFF
--- a/PushNotification/PushNotification/PushNotification.Plugin.iOS/PushNotificationImplementation.cs
+++ b/PushNotification/PushNotification/PushNotification.Plugin.iOS/PushNotificationImplementation.cs
@@ -125,12 +125,10 @@ namespace PushNotification.Plugin
 
 		public void OnUnregisteredSuccess ()
 		{
+            CrossPushNotification.PushNotificationListener.OnUnregistered(DeviceType.iOS);
+
             NSUserDefaults.StandardUserDefaults.SetString(string.Empty, PushNotificationKey.Token);
             NSUserDefaults.StandardUserDefaults.Synchronize();
-
-            CrossPushNotification.PushNotificationListener.OnUnregistered(DeviceType.iOS);
-           
-
         }
 
 		#endregion


### PR DESCRIPTION
Clear token after call to OnUnregistered, so you know which token actually unsubscribes.
