### PR TITLE
Make explicit which using required

### DIFF
--- a/PushNotification/README.md
+++ b/PushNotification/README.md
@@ -62,6 +62,12 @@ public override void OnCreate()
 Must implement IPushNotificationListener. This would be commonly implemented in the Core project if sharing code between Android or iOS. In the case you are using the plugin only for a specific platform this would be implemented in that platform.
 
 ```
+using Newtonsoft.Json.Linq;
+using PushNotification.Plugin;
+using PushNotification.Plugin.Abstractions;
+
+....
+
 public class  CrossPushNotificationListener : IPushNotificationListener
     {
         //Here you will receive all push notification messages


### PR DESCRIPTION
Seems to be very common in project documentation to not specify the dependencies leaving the user to guess.